### PR TITLE
Add --prefix option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,11 +9,17 @@ use std::path::PathBuf;
 struct Params {
     /// The repositories to summarize
     repositories: Vec<PathBuf>,
+
+    /// Prefix for each shell var line (e.g. 'local ')
+    #[clap(long, short = 'p')]
+    prefix: Option<String>,
 }
 
 fn main() {
     let params = Params::parse();
-    let out = ShellWriter::default();
+    let out = ShellWriter::with_prefix(
+        params.prefix.unwrap_or_else(|| String::from("")),
+    );
 
     if params.repositories.is_empty() {
         summarize_repository(&out, Repository::open_from_env());

--- a/src/shell_writer.rs
+++ b/src/shell_writer.rs
@@ -85,6 +85,13 @@ impl<W: io::Write> ShellWriter<W> {
     }
 }
 
+impl ShellWriter<io::Stdout> {
+    /// Create a new `ShellWriter` for [`io::stdout()`] and a prefix.
+    pub fn with_prefix(prefix: String) -> Self {
+        Self::new(io::stdout(), prefix)
+    }
+}
+
 impl Default for ShellWriter<io::Stdout> {
     /// Create a new `ShellWriter` for [`io::stdout()`] and no prefix.
     fn default() -> Self {


### PR DESCRIPTION
Add option to allow specifying a prefix for every shell var output line. For example, you might specify `--prefix 'local '` to get:

    local repo_state=Clean
    local repo_empty=false
    ...