### PR TITLE
Cargo.toml: Rust 2021, no badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,7 @@ readme = "README.md"
 keywords = ["git", "shell", "prompt", "zsh", "bash"]
 categories = ["development-tools", "command-line-utilities"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
-
-[badges]
-maintenance = { status = "actively-developed" }
+edition = "2021"
 
 [dependencies]
 clap = { version = "4.0.16", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ pub fn head_info(repository: &Repository) -> Result<Head, git2::Error> {
                 }
                 None => {
                     head.trail.push(Reference::new(
-                        &display_option(reference.name()),
+                        display_option(reference.name()),
                         "unknown",
                     ));
                     break;

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn summarize_repository<W: std::io::Write>(
 
     if let Err(error) = result {
         out.write_var("repo_state", "Error");
-        out.write_var_debug("repo_error", &error);
+        out.write_var_debug("repo_error", error);
     }
 }
 


### PR DESCRIPTION
The badges section seems to be no longer used, and I’m not sure how accurate “actively developed” really is — I add features and fix bugs as they come up, but I don’t have much planned at the moment.

Switched to Rust 2021 to keep things fresh.
