### PR TITLE
Release workflow copied from cargo-hack

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,89 @@
+# Mostly copied from https://github.com/taiki-e/cargo-hack/blob/72a9fc95377c453a18026329577c59fa60bfa737/.github/workflows/release.yml
+name: Release
+
+permissions:
+  # TODO: once `releases: write` is supported, use it instead.
+  contents: write
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+
+defaults:
+  run:
+    # Setting shell: bash explicitly activates pipefail
+    shell: bash
+
+jobs:
+  create-release:
+    if: github.repository_owner == 'danielparks'
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        run: rustup update stable --no-self-update
+      - run: cargo package
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          changelog: CHANGELOG.md
+          title: Release $version
+          branch: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  upload-assets:
+    name: ${{ matrix.target }}
+    if: github.repository_owner == 'danielparks'
+    needs:
+      - create-release
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-musl
+          - target: aarch64-apple-darwin
+            os: macos-11
+          - target: aarch64-pc-windows-msvc
+            os: windows-2019
+          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
+          - target: x86_64-apple-darwin
+            os: macos-11
+          - target: x86_64-pc-windows-msvc
+            os: windows-2019
+          - target: x86_64-unknown-freebsd
+    runs-on: ${{ matrix.os || 'ubuntu-18.04' }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        run: rustup update stable --no-self-update
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+        if: (matrix.os == '' || startsWith(matrix.os, 'ubuntu')) && !contains(matrix.target, '-musl')
+      - uses: taiki-e/install-action@cross
+        if: contains(matrix.target, '-musl')
+      - run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static" >> "${GITHUB_ENV}"
+        if: endsWith(matrix.target, 'windows-msvc')
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: cargo-hack
+          target: ${{ matrix.target }}
+          tar: all
+          zip: windows
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+# Release process
+
+1. Create a release branch “release-vX.Y.Z” and submit as a PR.
+  1. Update version in Cargo.toml and Cargo.lock.
+  2. Replace "## main branch" with "## Release {{version}} ({{date}})" in
+     CHANGELOG.md.
+  3. Commit with message: "Release {{version}}."
+2. Create release tag “vX.Y.Z”.
+  1. Get the release notes from CHANGELOG.md, set as the tag body.
+  2. Push tag to origin. The release.yaml workflow will run on GitHub, publish
+     the package to crates.io, and build and publish binaries.
+3. Post-release commit:
+  1. Insert "## main branch" above first "## Release" in CHANGELOG.md.
+  2. Commit with message: "Prepping CHANGELOG.md for development."
+  3. Push to origin.


### PR DESCRIPTION
This is almost a straight copy of the [release workflow][] from [cargo-hack][]. When a vX.Y.Z tag is pushes, it should create a GitHub release with notes from CHANGELOG.md, build binaries for various platforms, package the binaries into archives, and attach them to the GitHub release.

I have commented out the code that actually publishes the release to crates.io.

This also adds a bare-bones document describing how to cut a release.

Part of #3 — Make it easy to download binaries.

[release workflow]: https://github.com/taiki-e/cargo-hack/blob/72a9fc95377c453a18026329577c59fa60bfa737/.github/workflows/release.yml
[cargo-hack]: https://github.com/taiki-e/cargo-hack