### PR TITLE
Release 0.2.4: upgrade git2 for security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## main branch
+## Release 0.2.4 (2023-01-21)
+
+### Security fixes
+
+* Upgrade [git2] dependency to 0.16.1 to fix a [security vulnerability in its
+  handling of SSH keys][GHSA-m4ch-rfv5-x5g3]. This was unlikely to affect
+  git-status-vars since it doesn’t fetch data from, or otherwise interact with,
+  remote repositories.
+
+[git2]: https://crates.io/crates/git2
+[GHSA-m4ch-rfv5-x5g3]: https://github.com/rust-lang/git2-rs/security/advisories/GHSA-m4ch-rfv5-x5g3
 
 ## Release 0.2.3 (2022-12-31)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "git-status-vars"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "assert_cmd",
  "bstr",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
 dependencies = [
  "bitflags",
  "libc",
@@ -272,9 +272,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.0+1.5.0"
+version = "0.14.2+1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
+checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-status-vars"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Daniel Parks <oss-git-status-vars@demonhorse.org>"]
 description = "Summarize git repo info into shell variables (for use in a prompt)"
 homepage = "https://github.com/danielparks/git-status-vars"
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.0.16", features = ["derive"] }
-git2 = { version = "0.15.0", default-features = false }
+git2 = { version = "0.16.1", default-features = false }
 shell-words = "1.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This upgrades the [git2] dependency to 0.16.1 to fix a [security vulnerability in its handling of SSH keys][GHSA-m4ch-rfv5-x5g3]. This was unlikely to affect git-status-vars since it doesn’t fetch data from, or otherwise interact with, remote repositories.

[git2]: https://crates.io/crates/git2
[GHSA-m4ch-rfv5-x5g3]: https://github.com/rust-lang/git2-rs/security/advisories/GHSA-m4ch-rfv5-x5g3