### PR TITLE
Track minimum supported Rust version (MSRV)

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -42,3 +42,15 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
+
+  msrv:
+    name: cargo msrv
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-msrv
+      - run: cargo msrv verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 * Document versioning policy — the version primarily tracks changes to the
   binary, not the crate as a library.
+* Document that the minimum supported Rust version (MSRV) is 1.60.
 
 ## Release 0.2.4 (2023-01-21)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["git", "shell", "prompt", "zsh", "bash"]
 categories = ["development-tools", "command-line-utilities"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.60"
 
 [dependencies]
 clap = { version = "4.0.16", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -134,8 +134,11 @@ I have not tested this on large repositories.
 
 [![docs.rs](https://img.shields.io/docsrs/git-status-vars)][docs.rs]
 [![Crates.io](https://img.shields.io/crates/v/git-status-vars)][crates.io]
+![Rust version 1.60+](https://img.shields.io/badge/Rust%20version-1.60%2B-success)
 
 I’m not sure how useful it is, but this may be used from other Rust code.
+
+Currently the minimum supported Rust version (MSRV) is **1.60**.
 
 ## Development and contributions
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 //! The primary entrance to this code is [`summarize_repository()`]. It opens a
 //! [`Repository`], then calls [`summarize_opened_repository()`] on it.
 //!
+//! Currently the minimum supported Rust version (MSRV) is **1.60**.
+//!
 //! # Versioning
 //!
 //! This follows semantic versioning for the command line utility, not the crate


### PR DESCRIPTION
This doesn’t change anything functional; it just documents the MSRV and adds a CI check to confirm it.