### PR TITLE
Forbid unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@
 //! anyone else.
 //!
 //! [README.md]: https://github.com/danielparks/git-status-vars/blob/main/README.md
+
+#![forbid(unsafe_code)]
+
 use git2::Branch;
 use git2::ReferenceType;
 use git2::Repository;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use clap::Parser;
 use git2::Repository;
 use git_status_vars::{summarize_repository, ShellWriter};


### PR DESCRIPTION
It seems unlikely I’ll need `unsafe`. Make our non-usage of `unsafe` explicit.