### PR TITLE
Enable most pedantic clippy lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+* Added missing crate documentation.
+
+### Bug fixes
+
+* Ensured that `summarize_opened_repository()` would not produce output before
+  returning an error. This could have caused confusing output from
+  `summarize_repository()`.
+
 ## Release 1.0.0 (2023-04-05)
 
 Bumping to version 1.0.0 to indicate stability. There are no functional changes.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::let_underscore_untyped, clippy::map_unwrap_or)]
 
 use clap::Parser;
 use git2::Repository;
@@ -18,9 +20,7 @@ struct Params {
 
 fn main() {
     let params = Params::parse();
-    let out = ShellWriter::with_prefix(
-        params.prefix.unwrap_or_else(|| String::from("")),
-    );
+    let out = ShellWriter::with_prefix(params.prefix.unwrap_or_default());
 
     if params.repositories.is_empty() {
         summarize_repository(&out, Repository::open_from_env());

--- a/src/shell_writer.rs
+++ b/src/shell_writer.rs
@@ -26,6 +26,7 @@ impl<W: io::Write> ShellWriter<W> {
     /// ShellWriter::new(&mut buffer, "").group("group").write_var("var", "value");
     /// assert_eq!(buffer, b"group_var=value\n");
     /// ```
+    #[must_use]
     pub fn new(writer: W, prefix: impl Display) -> Self {
         Self {
             writer: Rc::new(RefCell::new(writer)),
@@ -64,6 +65,7 @@ impl<W: io::Write> ShellWriter<W> {
     /// ```sh
     /// prefix_group_var=value
     /// ```
+    #[must_use]
     pub fn group(&self, group: impl Display) -> ShellWriter<W> {
         ShellWriter {
             writer: self.writer.clone(),
@@ -76,6 +78,7 @@ impl<W: io::Write> ShellWriter<W> {
     /// ```sh
     /// prefix_groupN_var=value
     /// ```
+    #[must_use]
     pub fn group_n(
         &self,
         prefix: impl Display,
@@ -87,6 +90,7 @@ impl<W: io::Write> ShellWriter<W> {
 
 impl ShellWriter<io::Stdout> {
     /// Create a new `ShellWriter` for [`io::stdout()`] and a prefix.
+    #[must_use]
     pub fn with_prefix(prefix: String) -> Self {
         Self::new(io::stdout(), prefix)
     }
@@ -113,6 +117,7 @@ where
 
 /// An object that can be written as a group of shell variables.
 pub trait ShellVars {
+    /// Write `self` to the shell writer `out`.
     fn write_to_shell<W: io::Write>(&self, out: &ShellWriter<W>);
 }
 


### PR DESCRIPTION
Along this way, this adds a lot of missing documentation.

It also fixes a bug where an error might have been encounted after `summarize_opened_repository()` had already started outputting information about the repository.