### PR TITLE
Apply the same clippy rules everywhere

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-features --all-targets
 
   msrv:
     name: cargo msrv

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,20 @@
+//! git-status-vars executable.
+
 #![forbid(unsafe_code)]
 #![warn(clippy::pedantic)]
-#![allow(clippy::let_underscore_untyped, clippy::map_unwrap_or)]
+#![allow(
+    clippy::let_underscore_untyped,
+    clippy::manual_string_new,
+    clippy::map_unwrap_or
+)]
+#![warn(missing_docs, clippy::missing_docs_in_private_items)]
 
 use clap::Parser;
 use git2::Repository;
 use git_status_vars::{summarize_repository, ShellWriter};
 use std::path::PathBuf;
 
+/// Parameters to configure executable.
 #[derive(Debug, clap::Parser)]
 #[clap(version, about)]
 struct Params {

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -48,7 +48,7 @@ where
     I: IntoIterator<Item = S>,
     S: Into<OsString>,
 {
-    let args: Vec<OsString> = args.into_iter().map(|arg| arg.into()).collect();
+    let args: Vec<OsString> = args.into_iter().map(Into::into).collect();
     let shell_args =
         shell_words::join(args.iter().map(|arg| arg.to_string_lossy()));
 
@@ -137,7 +137,7 @@ pub fn assert_git_status_vars(root: &Path, repo: &str, expected: &str) {
     let expected = if expected.bytes().next() == Some(b'\n') {
         if let Some(i) = expected[1..].find(|c: char| c != ' ') {
             // We skipped the first newline, so add 1 to the result.
-            expected[i + 1..].replace(&expected[..i + 1], "\n")
+            expected[i + 1..].replace(&expected[..=i], "\n")
         } else {
             // Didn’t find non-space character.
             String::from("")

--- a/tests/repos.rs
+++ b/tests/repos.rs
@@ -1,3 +1,12 @@
+#![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::let_underscore_untyped,
+    clippy::manual_string_new,
+    clippy::map_unwrap_or
+)]
+#![warn(missing_docs, clippy::missing_docs_in_private_items)]
+
 use std::fs;
 use target_test_dir::with_test_dir;
 


### PR DESCRIPTION
Previously we used slightly different rules for `main.rs` and `lib.rs`. This makes them consistent. It also applies the same configuration to tests, and fixes newly found lint violations.