### PR TITLE
Add `clippy::nursery` lints and more

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,17 @@
 //! git-status-vars executable.
 
 #![forbid(unsafe_code)]
-#![warn(clippy::pedantic)]
+#![warn(clippy::nursery, clippy::pedantic)]
 #![allow(
     clippy::let_underscore_untyped,
     clippy::manual_string_new,
-    clippy::map_unwrap_or
+    clippy::map_unwrap_or,
+    clippy::module_name_repetitions
 )]
+// Require docs on everything
 #![warn(missing_docs, clippy::missing_docs_in_private_items)]
+// Other restriction lints
+#![warn(clippy::arithmetic_side_effects)]
 
 use clap::Parser;
 use git2::Repository;
@@ -38,7 +42,7 @@ fn main() {
         out.write_var("repo_count", params.repositories.len());
         for (i, repo_path) in params.repositories.iter().enumerate() {
             println!();
-            let repo_out = &out.group_n("repo", i + 1);
+            let repo_out = &out.group_n("repo", i.wrapping_add(1));
             repo_out.write_var("path", repo_path.display());
             summarize_repository(repo_out, Repository::open(repo_path));
         }

--- a/src/shell_writer.rs
+++ b/src/shell_writer.rs
@@ -69,8 +69,8 @@ impl<W: io::Write> ShellWriter<W> {
     /// prefix_group_var=value
     /// ```
     #[must_use]
-    pub fn group(&self, group: impl Display) -> ShellWriter<W> {
-        ShellWriter {
+    pub fn group(&self, group: impl Display) -> Self {
+        Self {
             writer: self.writer.clone(),
             prefix: format!("{}{}_", self.prefix, group),
         }
@@ -82,11 +82,7 @@ impl<W: io::Write> ShellWriter<W> {
     /// prefix_groupN_var=value
     /// ```
     #[must_use]
-    pub fn group_n(
-        &self,
-        prefix: impl Display,
-        n: impl Display,
-    ) -> ShellWriter<W> {
+    pub fn group_n(&self, prefix: impl Display, n: impl Display) -> Self {
         self.group(format!("{prefix}{n}"))
     }
 }
@@ -106,10 +102,7 @@ impl Default for ShellWriter<io::Stdout> {
     }
 }
 
-impl<W: io::Write> Debug for ShellWriter<W>
-where
-    W: Debug,
-{
+impl<W: io::Write + Debug> Debug for ShellWriter<W> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("ShellWriter")
             .field("writer", &self.writer)

--- a/tests/meta.rs
+++ b/tests/meta.rs
@@ -1,0 +1,40 @@
+//! Test the test helpers.
+
+#![forbid(unsafe_code)]
+#![warn(clippy::nursery, clippy::pedantic)]
+#![allow(
+    clippy::let_underscore_untyped,
+    clippy::manual_string_new,
+    clippy::map_unwrap_or,
+    clippy::module_name_repetitions
+)]
+// Require docs on everything
+#![warn(missing_docs, clippy::missing_docs_in_private_items)]
+// Other restriction lints
+#![warn(clippy::arithmetic_side_effects)]
+
+// We don’t use everything in helpers.
+#[allow(dead_code)]
+mod helpers;
+
+#[test]
+fn test_strip_indent_change() {
+    assert_eq!(
+        helpers::strip_indent(
+            "
+            No newline before this.
+            Second line.
+                Indented line.
+            "
+        ),
+        "No newline before this.\nSecond line.\n    Indented line.\n",
+    );
+}
+
+#[test]
+fn test_strip_indent_unchanged() {
+    let unchanged = "Doesn’t start with a newline
+        This indent will not be removed.
+        In fact, nothing will change.";
+    assert_eq!(helpers::strip_indent(unchanged), unchanged);
+}

--- a/tests/repos.rs
+++ b/tests/repos.rs
@@ -1,11 +1,15 @@
 #![forbid(unsafe_code)]
-#![warn(clippy::pedantic)]
+#![warn(clippy::nursery, clippy::pedantic)]
 #![allow(
     clippy::let_underscore_untyped,
     clippy::manual_string_new,
-    clippy::map_unwrap_or
+    clippy::map_unwrap_or,
+    clippy::module_name_repetitions
 )]
+// Require docs on everything
 #![warn(missing_docs, clippy::missing_docs_in_private_items)]
+// Other restriction lints
+#![warn(clippy::arithmetic_side_effects)]
 
 use std::fs;
 use target_test_dir::with_test_dir;


### PR DESCRIPTION
This adds the `clippy::nursery` lints and `clippy::arithmetic_side_effects`. It makes fixes to ensure the new lints pass.