### PR TITLE
Update `ShellWriter::with_prefix()` to accept `impl Display`

### DIFF
--- a/src/shell_writer.rs
+++ b/src/shell_writer.rs
@@ -90,7 +90,7 @@ impl<W: io::Write> ShellWriter<W> {
 impl ShellWriter<io::Stdout> {
     /// Create a new `ShellWriter` for [`io::stdout()`] and a prefix.
     #[must_use]
-    pub fn with_prefix(prefix: String) -> Self {
+    pub fn with_prefix(prefix: impl Display) -> Self {
         Self::new(io::stdout(), prefix)
     }
 }


### PR DESCRIPTION
Previously it accepted only a `String` for the prefix, despite internally passing the parameter to a constructor that takes `impl Display`.