### PR TITLE
Use generics instead of `impl` in parameters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,11 @@
 // Require docs on everything
 #![warn(missing_docs, clippy::missing_docs_in_private_items)]
 // Other restriction lints
-#![warn(clippy::arithmetic_side_effects, clippy::dbg_macro)]
+#![warn(
+    clippy::arithmetic_side_effects,
+    clippy::dbg_macro,
+    clippy::impl_trait_in_params
+)]
 
 use git2::Branch;
 use git2::ReferenceType;
@@ -314,7 +318,7 @@ pub fn get_upstream_difference(
 }
 
 /// Format `Option<impl fmt::Display>` for display. `None` becomes `""`.
-fn display_option(s: Option<impl fmt::Display>) -> String {
+fn display_option<V: fmt::Display>(s: Option<V>) -> String {
     s.map(|s| s.to_string()).unwrap_or_else(|| "".to_string())
 }
 


### PR DESCRIPTION
This is necessary to enable use of the turbofish operator, but more generally it’s nice to be consistent.

This enables the [clippy::impl_trait_in_params] lint, but for some reason it doesn’t actually catch all instances of `impl` in parameters.

[clippy::impl_trait_in_params]: https://rust-lang.github.io/rust-clippy/master/index.html#/impl_trait_in_params