### PR TITLE
Use `fmt::Display` instead of `AsRef<str>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+### API breaking changes
+
+* Switched `Reference::new()` and friends to accept types that implement
+  `std::fmt::Display` instead of `AsRef<str>`. The functions convert the
+  parameters to owned `String`s with `to_string()` anyway, so this more
+  accurately reflects what the functions are doing.
+
+### Other API changes
+
+* `ShellWriter::with_prefix()` now accepts anything that implements
+  `std::fmt::Display` as the prefix rather than just `String`s.
+
 ## Release 1.0.2 (2023-05-24)
 
 * Update documentation to reflect that the minimum supported Rust version

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,14 +61,10 @@ pub struct Reference {
 impl Reference {
     /// Create a new reference without an error.
     #[must_use]
-    pub fn new<N, K>(name: N, kind: K) -> Self
-    where
-        N: AsRef<str>,
-        K: AsRef<str>,
-    {
+    pub fn new<N: fmt::Display, K: fmt::Display>(name: N, kind: K) -> Self {
         Self {
-            name: name.as_ref().to_string(),
-            kind: kind.as_ref().to_string(),
+            name: name.to_string(),
+            kind: kind.to_string(),
             error: "".to_string(),
         }
     }
@@ -77,26 +73,26 @@ impl Reference {
     #[must_use]
     pub fn new_with_error<N, K, E>(name: N, kind: K, error: E) -> Self
     where
-        N: AsRef<str>,
-        K: AsRef<str>,
+        N: fmt::Display,
+        K: fmt::Display,
         E: fmt::Debug,
     {
         Self {
-            name: name.as_ref().to_string(),
-            kind: kind.as_ref().to_string(),
+            name: name.to_string(),
+            kind: kind.to_string(),
             error: format!("{error:?}"),
         }
     }
 
     /// Create a new symbolic reference.
     #[must_use]
-    pub fn symbolic(name: &str) -> Self {
+    pub fn symbolic<N: fmt::Display>(name: N) -> Self {
         Self::new(name, "symbolic")
     }
 
     /// Create a new direct reference.
     #[must_use]
-    pub fn direct(name: &str) -> Self {
+    pub fn direct<N: fmt::Display>(name: N) -> Self {
         Self::new(name, "direct")
     }
 
@@ -246,14 +242,14 @@ pub fn head_info(repository: &Repository) -> Head {
         match repository.find_reference(&current) {
             Ok(reference) => match reference.kind() {
                 Some(ReferenceType::Direct) => {
-                    head.trail.push(Reference::direct(&display_option(
+                    head.trail.push(Reference::direct(display_option(
                         reference.name(),
                     )));
                     head.hash = display_option(reference.target());
                     break;
                 }
                 Some(ReferenceType::Symbolic) => {
-                    head.trail.push(Reference::symbolic(&display_option(
+                    head.trail.push(Reference::symbolic(display_option(
                         reference.name(),
                     )));
                     let target = reference


### PR DESCRIPTION
In places where we convert to a `String` with `to_string()` anyway, we might as well use a trait that provides that rather than one that allows us to get a `str`.

For some reason using the `ToString` trait causes clippy to complain about not using references, whereas using `fmt::Display` (which implies the `ToString` trait) does not.

This also adds a note in the CHANGELOG.md about updating `ShellWriter::with_prefix()`.