### PR TITLE
Use cargo-lints to centrally configure lints

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -38,10 +38,10 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-      - uses: actions-rs/clippy-check@v1
+      - uses: taiki-e/install-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets
+          tool: cargo-lints
+      - run: cargo lints clippy --all-features --all-targets
 
   msrv:
     name: cargo msrv

--- a/lints.toml
+++ b/lints.toml
@@ -1,0 +1,51 @@
+deny = [
+  "unsafe_code",
+]
+
+warn = [
+  "clippy::nursery",
+  "clippy::pedantic",
+
+  # Require docs
+  "missing_docs",
+  "clippy::missing_docs_in_private_items",
+
+  # Other restriction lints
+  "clippy::arithmetic_side_effects",
+  "clippy::as_underscore",
+  "clippy::assertions_on_result_states",
+  "clippy::dbg_macro",
+  "clippy::default_union_representation",
+  "clippy::empty_structs_with_brackets",
+  "clippy::filetype_is_file", # maybe?
+  "clippy::fn_to_numeric_cast_any",
+  "clippy::format_push_string", # maybe? alternative is fallible.
+  "clippy::get_unwrap",
+  "clippy::impl_trait_in_params",
+  "clippy::integer_division",
+  "clippy::lossy_float_literal",
+  "clippy::mem_forget",
+  "clippy::mixed_read_write_in_expression",
+  "clippy::multiple_inherent_impl",
+  "clippy::multiple_unsafe_ops_per_block",
+  "clippy::mutex_atomic",
+  "clippy::rc_buffer",
+  "clippy::rc_mutex",
+  "clippy::same_name_method",
+  "clippy::semicolon_inside_block",
+  "clippy::str_to_string",
+  "clippy::string_to_string",
+  "clippy::undocumented_unsafe_blocks",
+  "clippy::unnecessary_safety_doc",
+  "clippy::unnecessary_self_imports",
+  "clippy::unneeded_field_pattern",
+  "clippy::verbose_file_reads",
+]
+
+allow = [
+  # Pedantic exceptions
+  "clippy::let_underscore_untyped",
+  "clippy::manual_string_new",
+  "clippy::map_unwrap_or",
+  "clippy::module_name_repetitions",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,22 +15,9 @@
 //!
 //! [README.md]: https://github.com/danielparks/git-status-vars/blob/main/README.md
 
+// Most lint configuration is in lints.toml, but that isn’t supported by
+// cargo-geiger, and it only supports deny, not forbid.
 #![forbid(unsafe_code)]
-#![warn(clippy::nursery, clippy::pedantic)]
-#![allow(
-    clippy::let_underscore_untyped,
-    clippy::manual_string_new,
-    clippy::map_unwrap_or,
-    clippy::module_name_repetitions
-)]
-// Require docs on everything
-#![warn(missing_docs, clippy::missing_docs_in_private_items)]
-// Other restriction lints
-#![warn(
-    clippy::arithmetic_side_effects,
-    clippy::dbg_macro,
-    clippy::impl_trait_in_params
-)]
 
 use git2::Branch;
 use git2::ReferenceType;
@@ -65,7 +52,7 @@ impl Reference {
         Self {
             name: name.to_string(),
             kind: kind.to_string(),
-            error: "".to_string(),
+            error: "".to_owned(),
         }
     }
 
@@ -236,7 +223,7 @@ pub fn summarize_opened_repository<W: std::io::Write>(
 #[allow(clippy::similar_names)]
 #[must_use]
 pub fn head_info(repository: &Repository) -> Head {
-    let mut current = "HEAD".to_string();
+    let mut current = "HEAD".to_owned();
     let mut head = Head::default();
     loop {
         match repository.find_reference(&current) {
@@ -255,7 +242,7 @@ pub fn head_info(repository: &Repository) -> Head {
                     let target = reference
                         .symbolic_target()
                         .expect("Symbolic ref should have symbolic target");
-                    current = target.to_string();
+                    current = target.to_owned();
                 }
                 None => {
                     head.trail.push(Reference::new(
@@ -315,7 +302,7 @@ pub fn get_upstream_difference(
 
 /// Format `Option<impl fmt::Display>` for display. `None` becomes `""`.
 fn display_option<V: fmt::Display>(s: Option<V>) -> String {
-    s.map(|s| s.to_string()).unwrap_or_else(|| "".to_string())
+    s.map(|s| s.to_string()).unwrap_or_else(|| "".to_owned())
 }
 
 /// Track changes in the working tree and index (staged area).

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,5 @@
 //! git-status-vars executable.
 
-#![forbid(unsafe_code)]
-#![warn(clippy::nursery, clippy::pedantic)]
-#![allow(
-    clippy::let_underscore_untyped,
-    clippy::manual_string_new,
-    clippy::map_unwrap_or,
-    clippy::module_name_repetitions
-)]
-// Require docs on everything
-#![warn(missing_docs, clippy::missing_docs_in_private_items)]
-// Other restriction lints
-#![warn(clippy::arithmetic_side_effects, clippy::dbg_macro)]
-
 use clap::Parser;
 use git2::Repository;
 use git_status_vars::{summarize_repository, ShellWriter};

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -183,5 +183,5 @@ pub fn strip_indent(input: &str) -> String {
                 String::from(rest)
             }
         })
-        .unwrap_or_else(|| input.to_string())
+        .unwrap_or_else(|| input.to_owned())
 }

--- a/tests/meta.rs
+++ b/tests/meta.rs
@@ -1,18 +1,5 @@
 //! Test the test helpers.
 
-#![forbid(unsafe_code)]
-#![warn(clippy::nursery, clippy::pedantic)]
-#![allow(
-    clippy::let_underscore_untyped,
-    clippy::manual_string_new,
-    clippy::map_unwrap_or,
-    clippy::module_name_repetitions
-)]
-// Require docs on everything
-#![warn(missing_docs, clippy::missing_docs_in_private_items)]
-// Other restriction lints
-#![warn(clippy::arithmetic_side_effects, clippy::dbg_macro)]
-
 // We don’t use everything in helpers.
 #[allow(dead_code)]
 mod helpers;

--- a/tests/repos.rs
+++ b/tests/repos.rs
@@ -1,16 +1,3 @@
-#![forbid(unsafe_code)]
-#![warn(clippy::nursery, clippy::pedantic)]
-#![allow(
-    clippy::let_underscore_untyped,
-    clippy::manual_string_new,
-    clippy::map_unwrap_or,
-    clippy::module_name_repetitions
-)]
-// Require docs on everything
-#![warn(missing_docs, clippy::missing_docs_in_private_items)]
-// Other restriction lints
-#![warn(clippy::arithmetic_side_effects, clippy::dbg_macro)]
-
 use std::fs;
 use target_test_dir::with_test_dir;
 


### PR DESCRIPTION
Previously lints had to be configured at the top of every entry point in rust code — `lib.rs`, `main.rs`, and each test file. This allows lints to be centrally configured in `lints.toml` and ensures they are applied to all targets.

This also updates the lint list to match my other projects. It includes a bunch more restriction lints.

To run lints:

    cargo lints clippy --all-targets --all-features

This requires [cargo-lints] to be installed.

[cargo-lints]: https://crates.io/crates/cargo-lints