### PR TITLE
Security: update git2 to non-vulnerable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+### Security fixes
+
+* Upgrade [git2] dependency to 0.18.2 to fix [security vulnerabilities in
+  libgit2][GHSA-22q8-ghmq-63vf], including in revision parsing. These do not
+  appear to affect git-status-vars.
+
+[git2]: https://crates.io/crates/git2
+[GHSA-22q8-ghmq-63vf]: https://github.com/advisories/GHSA-22q8-ghmq-63vf
+
 ### API breaking changes
 
 * Switched `Reference::new()` and friends to accept types that implement

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
 name = "bstr"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,7 +149,7 @@ checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "strsim",
 ]
@@ -299,11 +305,11 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7905cdfe33d31a88bb2e8419ddd054451f5432d1da9eaf2ac7804ee1ea12d5"
+checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.2",
  "libc",
  "libgit2-sys",
  "log",
@@ -381,9 +387,9 @@ checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.15.1+1.6.4"
+version = "0.16.2+1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4577bde8cdfc7d6a2a4bcb7b049598597de33ffd337276e9c7db6cd4a2cee7"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",
@@ -557,7 +563,7 @@ version = "0.37.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.64"
 
 [dependencies]
 clap = { version = "4.0.16", features = ["derive"] }
-git2 = { version = "0.17.0", default-features = false }
+git2 = { version = "0.18.2", default-features = false }
 shell-words = "1.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
[git2] uses [libgit2] internally, which had [multiple security vulnerabilities][vuln], including in revision parsing. This updates `git2` to a version that uses a non-vulnerable version of `libgit2`.

It appears that git-status-vars was not affected by the vulnerabilities.

[git2]: https://crates.io/crates/git2
[libgit2]: https://github.com/libgit2/libgit2/
[vuln]: https://github.com/advisories/GHSA-22q8-ghmq-63vf