### PR TITLE
Release 1.0.3: security updates and breaking API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## main branch
+## Release 1.0.3 (2024-02-12)
 
 ### Security fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ checksum = "673464e1e314dd67a0fd9544abc99e8eb28d0c7e3b69b033bcff9b2d00b87333"
 
 [[package]]
 name = "git-status-vars"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "assert_cmd",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-status-vars"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Daniel Parks <oss-git-status-vars@demonhorse.org>"]
 description = "Summarize git repo info into shell variables (for use in a prompt)"
 homepage = "https://github.com/danielparks/git-status-vars"


### PR DESCRIPTION
This release updates a few dependencies to avoid security vulnerabilities that probably did not affect git-status-vars.

It also cleans up the API in a number of small ways. This is a breaking change to the API, but as stated in DEVELOPMENT.md, the version number tracks the command line utility, not the API. In the unlikely event that someone is using the API, the changes are fairly trivial.