### PR TITLE
Fix macOS release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,13 +52,13 @@ jobs:
           - target: aarch64-unknown-linux-gnu
           - target: aarch64-unknown-linux-musl
           - target: aarch64-apple-darwin
-            os: macos-11
+            os: macos-14
           - target: aarch64-pc-windows-msvc
             os: windows-2019
           - target: x86_64-unknown-linux-gnu
           - target: x86_64-unknown-linux-musl
           - target: x86_64-apple-darwin
-            os: macos-11
+            os: macos-13
           - target: x86_64-pc-windows-msvc
             os: windows-2019
           - target: x86_64-unknown-freebsd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## main branch
+## Release 1.1.1 (2025-02-12)
+
+* Bump version to fix release workflow.
 
 ## Release 1.1.0 (2025-02-12)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "673464e1e314dd67a0fd9544abc99e8eb28d0c7e3b69b033bcff9b2d00b87333"
 
 [[package]]
 name = "git-status-vars"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "assert_cmd",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-status-vars"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Daniel Parks <oss-git-status-vars@demonhorse.org>"]
 description = "Summarize git repo info into shell variables (for use in a prompt)"
 homepage = "https://github.com/danielparks/git-status-vars"


### PR DESCRIPTION
- **GitHub release workflow: update macOS runner versions.**
  

- **Release 1.1.1: bump version to fix release workflow.**
  