### PR TITLE
Experiment: use `alarm()` to time out after 1 second (by default).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +272,7 @@ dependencies = [
  "clap",
  "duct",
  "git2",
+ "nix",
  "pretty_assertions",
  "regex",
  "shell-words",
@@ -455,9 +462,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libgit2-sys"
@@ -500,6 +507,18 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "clap",
  "duct",
  "git2",
+ "libc",
  "nix",
  "pretty_assertions",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.74.1"
 [dependencies]
 clap = { version = "4.5.23", features = ["derive"] }
 git2 = { version = "0.20.0", default-features = false }
+nix = { version = "0.30.1", features = ["signal"] }
 shell-words = "1.1.0"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.74.1"
 [dependencies]
 clap = { version = "4.5.23", features = ["derive"] }
 git2 = { version = "0.20.0", default-features = false }
+libc = "0.2.174"
 nix = { version = "0.30.1", features = ["signal"] }
 shell-words = "1.1.0"
 tracing = "0.1.41"
@@ -33,7 +34,7 @@ target-test-dir = "0.3.0"
 workspace = true
 
 [workspace.lints.rust]
-unsafe_code = "forbid"
+unsafe_code = "allow"
 missing_docs = "warn"
 
 [workspace.lints.clippy]
@@ -48,9 +49,9 @@ assertions_on_result_states = "warn"
 dbg_macro = "warn"
 default_union_representation = "warn"
 empty_structs_with_brackets = "warn"
-filetype_is_file = "warn" # maybe?
+filetype_is_file = "warn"               # maybe?
 fn_to_numeric_cast_any = "warn"
-format_push_string = "warn" # maybe? alternative is fallible.
+format_push_string = "warn"             # maybe? alternative is fallible.
 get_unwrap = "warn"
 impl_trait_in_params = "warn"
 integer_division = "warn"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,9 @@ pub fn count_changes(
     options
         .show(StatusShow::IndexAndWorkdir)
         .include_untracked(true)
-        .exclude_submodules(true);
+        .exclude_submodules(true)
+        .no_refresh(true)
+        .update_index(false);
     let statuses = repository.statuses(Some(&mut options))?;
 
     let mut counters: [usize; 4] = [0; 4];

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,10 @@ struct Params {
     /// Print timing information to stderr
     #[clap(short, long)]
     pub verbose: bool,
+
+    /// Timeout in seconds (0 means no timeout)
+    #[clap(short, long, default_value = "1")]
+    pub timeout: u32,
 }
 
 fn main() {
@@ -36,6 +40,10 @@ fn main() {
         })
         .compact()
         .init();
+
+    if params.timeout != 0 {
+        nix::unistd::alarm::set(params.timeout);
+    }
 
     if params.repositories.is_empty() {
         summarize_repository(&out, Repository::open_from_env());


### PR DESCRIPTION
Potential fix for #67 