### PR TITLE
Add timeout option (default 1 second)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## main branch
 
+* Add `--timeout` option, which defaults to 1 second. `git-status-vars` will now
+  output as much repository information as it can, then end with:
+
+      repo_state=Error
+      repo_error='Timed out'
+
 ## Release 1.1.1 (2025-02-12)
 
 * Bump version to fix release workflow.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +272,8 @@ dependencies = [
  "clap",
  "duct",
  "git2",
+ "libc",
+ "nix",
  "pretty_assertions",
  "regex",
  "shell-words",
@@ -455,9 +463,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libgit2-sys"
@@ -500,6 +508,18 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ rust-version = "1.74.1"
 [dependencies]
 clap = { version = "4.5.23", features = ["derive"] }
 git2 = { version = "0.20.0", default-features = false }
+libc = "0.2.174"
+nix = { version = "0.30.1", features = ["signal"] }
 shell-words = "1.1.0"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
@@ -32,7 +34,7 @@ target-test-dir = "0.3.0"
 workspace = true
 
 [workspace.lints.rust]
-unsafe_code = "forbid"
+unsafe_code = "allow"
 missing_docs = "warn"
 
 [workspace.lints.clippy]
@@ -47,9 +49,9 @@ assertions_on_result_states = "warn"
 dbg_macro = "warn"
 default_union_representation = "warn"
 empty_structs_with_brackets = "warn"
-filetype_is_file = "warn" # maybe?
+filetype_is_file = "warn"               # maybe?
 fn_to_numeric_cast_any = "warn"
-format_push_string = "warn" # maybe? alternative is fallible.
+format_push_string = "warn"             # maybe? alternative is fallible.
 get_unwrap = "warn"
 impl_trait_in_params = "warn"
 integer_division = "warn"

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ git_prompt () {
 
 ```
 ~/projects/git-status-vars ❯ git-status-vars
-repo_state=Clean
 repo_workdir=/Users/daniel/projects/git-status-vars/
 repo_empty=false
 repo_bare=false
@@ -117,6 +116,7 @@ unstaged_count=0
 staged_count=0
 conflicted_count=0
 stash_count=0
+repo_state=Clean
 ~/projects/git-status-vars ❯ cd /
 / ❯ git-status-vars
 repo_state=NotFound
@@ -128,6 +128,27 @@ repo_state=NotFound
 is fast enough that the difference will not usually be perceptible. On my laptop
 `git-status-vars` typically runs in around 8 ms whereas the fallback code
 involving multiple calls to `git` takes around 25 ms.
+
+By default, `git-status-vars` times out after 1 second. It will output as much
+information about the repository as it can, and then it will output
+`repo_state=Error`. Example output:
+
+```
+repo_workdir=/Users/daniel/personal/projects/git-status-vars/
+repo_empty=false
+repo_bare=false
+head_ref_length=1
+head_ref1_name=refs/heads/timeout
+head_ref1_short=timeout
+head_ref1_kind=direct
+head_ref1_error=''
+head_hash=768535e06fe7255908ea0b16c47b6b676b86b6af
+head_ahead=2
+head_behind=3
+head_upstream_error=''
+repo_state=Error
+repo_error='Timed out'
+```
 
 I have not tested this on large repositories.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,10 @@
 use clap::Parser;
 use git2::Repository;
 use git_status_vars::{summarize_repository, ShellWriter};
+use nix::sys::signal::{
+    sigaction, SaFlags, SigAction, SigHandler, SigSet, Signal,
+};
+use nix::unistd::write;
 use std::io;
 use std::path::PathBuf;
 
@@ -20,10 +24,16 @@ struct Params {
     /// Print timing information to stderr
     #[clap(short, long)]
     pub verbose: bool,
+
+    /// Timeout in seconds (0 means no timeout)
+    #[clap(short, long, default_value = "1")]
+    pub timeout: u32,
 }
 
 fn main() {
     let params = Params::parse();
+    install_timeout(params.timeout);
+
     let out = ShellWriter::with_prefix(params.prefix.unwrap_or_default());
 
     tracing_subscriber::fmt()
@@ -49,5 +59,55 @@ fn main() {
             repo_out.write_var("path", repo_path.display());
             summarize_repository(repo_out, Repository::open(repo_path));
         }
+    }
+}
+
+/// Set up the timeout.
+///
+/// This uses [`alarm()`] and a signal handler to kill this process if it takes
+/// too long (more than `timeout` seconds).
+///
+/// [`alarm()`]: https://man7.org/linux/man-pages/man2/alarm.2.html
+fn install_timeout(timeout: u32) {
+    if timeout == 0 {
+        return;
+    }
+
+    let alarm_action = SigAction::new(
+        SigHandler::Handler(sigalrm_handler),
+        SaFlags::empty(),
+        SigSet::empty(),
+    );
+
+    // Safety: see `sigaction` documentation:
+    //
+    //   1. The signal handler only uses async-signal-safe functions.
+    //   2. We ignore the old signal handler.
+    unsafe {
+        let _ = sigaction(Signal::SIGALRM, &alarm_action);
+    }
+
+    nix::unistd::alarm::set(timeout);
+}
+
+/// Signal handler for SIGALRM (for timeout).
+///
+/// This only calls [async-signal-safe] functions.
+///
+/// [async-signal-safe]: https://man7.org/linux/man-pages/man7/signal-safety.7.html
+extern "C" fn sigalrm_handler(_: nix::libc::c_int) {
+    // Start with a newline in case we were in the middle of printing a line.
+    let _ = write(
+        std::io::stdout(),
+        b"\nrepo_state=Error\nrepo_error='Timed out'\n",
+    );
+
+    // Safety: some things might not be cleaned up. However:
+    //
+    //   1. We shouldn’t be making changes to the git repo.
+    //   2. Even if we were making changes, git is resilient to being killed in
+    //      the middle of an operation.
+    unsafe {
+        libc::_exit(2);
     }
 }

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -116,7 +116,6 @@ pub fn make_commit(root: &Path, repo: &str, n: u8) {
 ///     &root,
 ///     "repo"
 ///     r#"
-///     repo_state=Clean
 ///     repo_workdir=@REPO@/
 ///     repo_empty=false
 ///     repo_bare=false
@@ -128,6 +127,7 @@ pub fn make_commit(root: &Path, repo: &str, n: u8) {
 ///     head_hash=@HASH@
 ///     . . .
 ///     stash_count=0
+///     repo_state=Clean
 ///     "#,
 /// );
 /// ```

--- a/tests/repos.rs
+++ b/tests/repos.rs
@@ -28,7 +28,6 @@ fn empty() {
         &root,
         "repo",
         r#"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=true
         repo_bare=false
@@ -46,6 +45,7 @@ fn empty() {
         staged_count=0
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         "#,
     );
 }
@@ -63,7 +63,6 @@ fn empty_untracked() {
         &root,
         "repo",
         r#"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=true
         repo_bare=false
@@ -81,6 +80,7 @@ fn empty_untracked() {
         staged_count=0
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         "#,
     );
 }
@@ -99,7 +99,6 @@ fn empty_added() {
         &root,
         "repo",
         r#"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=true
         repo_bare=false
@@ -117,6 +116,7 @@ fn empty_added() {
         staged_count=1
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         "#,
     );
 }
@@ -136,7 +136,6 @@ fn empty_untracked_added() {
         &root,
         "repo",
         r#"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=true
         repo_bare=false
@@ -154,6 +153,7 @@ fn empty_untracked_added() {
         staged_count=1
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         "#,
     );
 }
@@ -171,7 +171,6 @@ fn commit() {
         &root,
         "repo",
         r#"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -189,6 +188,7 @@ fn commit() {
         staged_count=0
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         "#,
     );
 }
@@ -207,7 +207,6 @@ fn commit_delete() {
         &root,
         "repo",
         r#"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -225,6 +224,7 @@ fn commit_delete() {
         staged_count=0
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         "#,
     );
 }
@@ -243,7 +243,6 @@ fn commit_delete_staged() {
         &root,
         "repo",
         r#"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -261,6 +260,7 @@ fn commit_delete_staged() {
         staged_count=1
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         "#,
     );
 }
@@ -279,7 +279,6 @@ fn commit_modified() {
         &root,
         "repo",
         r#"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -297,6 +296,7 @@ fn commit_modified() {
         staged_count=0
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         "#,
     );
 }
@@ -316,7 +316,6 @@ fn commit_modified_staged() {
         &root,
         "repo",
         r#"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -334,6 +333,7 @@ fn commit_modified_staged() {
         staged_count=1
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         "#,
     );
 }
@@ -353,7 +353,6 @@ fn detached() {
         &root,
         "repo",
         r#"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -367,6 +366,7 @@ fn detached() {
         staged_count=0
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         "#,
     );
 }
@@ -385,7 +385,6 @@ fn branch() {
         &root,
         "repo",
         r#"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -403,6 +402,7 @@ fn branch() {
         staged_count=0
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         "#,
     );
 }
@@ -427,7 +427,6 @@ fn sym_ref() {
         &root,
         "repo",
         r#"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -449,6 +448,7 @@ fn sym_ref() {
         staged_count=0
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         "#,
     );
 }
@@ -470,7 +470,6 @@ fn tag() {
         &root,
         "repo",
         r#"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -484,6 +483,7 @@ fn tag() {
         staged_count=0
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         "#,
     );
 }
@@ -507,7 +507,6 @@ fn cherry_pick() {
         &root,
         "repo",
         r#"
-        repo_state=CherryPick
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -525,6 +524,7 @@ fn cherry_pick() {
         staged_count=0
         conflicted_count=2
         stash_count=0
+        repo_state=CherryPick
         "#,
     );
 }
@@ -550,7 +550,6 @@ fn cherry_pick_staged() {
         &root,
         "repo",
         r#"
-        repo_state=CherryPick
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -568,6 +567,7 @@ fn cherry_pick_staged() {
         staged_count=1
         conflicted_count=1
         stash_count=0
+        repo_state=CherryPick
         "#,
     );
 }
@@ -594,7 +594,6 @@ fn cherry_pick_unstaged() {
         &root,
         "repo",
         r#"
-        repo_state=CherryPick
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -612,6 +611,7 @@ fn cherry_pick_unstaged() {
         staged_count=0
         conflicted_count=1
         stash_count=0
+        repo_state=CherryPick
         "#,
     );
 }
@@ -635,7 +635,6 @@ fn conflict() {
         &root,
         "repo",
         r#"
-        repo_state=Merge
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -653,6 +652,7 @@ fn conflict() {
         staged_count=0
         conflicted_count=2
         stash_count=0
+        repo_state=Merge
         "#,
     );
 }
@@ -671,7 +671,6 @@ fn bare() {
         &root,
         "bare",
         r#"
-        repo_state=Clean
         repo_workdir=''
         repo_empty=false
         repo_bare=true
@@ -689,6 +688,7 @@ fn bare() {
         staged_count=0
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         "#,
     );
 }
@@ -708,7 +708,6 @@ fn ahead_1() {
         &root,
         "clone",
         r"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -726,6 +725,7 @@ fn ahead_1() {
         staged_count=0
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         ",
     );
 }
@@ -747,7 +747,6 @@ fn ahead_1_behind_1() {
         &root,
         "clone",
         r"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -765,6 +764,7 @@ fn ahead_1_behind_1() {
         staged_count=0
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         ",
     );
 }
@@ -785,7 +785,6 @@ fn behind_1() {
         &root,
         "clone",
         r"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -803,6 +802,7 @@ fn behind_1() {
         staged_count=0
         conflicted_count=0
         stash_count=0
+        repo_state=Clean
         ",
     );
 }
@@ -822,7 +822,6 @@ fn stashed_1() {
         &root,
         "repo",
         r#"
-        repo_state=Clean
         repo_workdir=@REPO@/
         repo_empty=false
         repo_bare=false
@@ -840,6 +839,7 @@ fn stashed_1() {
         staged_count=0
         conflicted_count=0
         stash_count=1
+        repo_state=Clean
         "#,
     );
 }


### PR DESCRIPTION
- **Status: explicitly don’t update repository.**
  `git-status-vars` should not change the repository, since it’s designed
  to be used in a shell prompt and it would be surprising if a shell
  prompt updated the repository.
  

- **Add a basic timeout (1 second by default)**
  This uses [`alarm()`] to kill the `git-status-vars` process if it takes
  too long.
  
  This switches to outputting repo information as soon as possible, but
  only outputting `repo_state=` at the end — if an error is encountered,
  it can still be reported through `repo_state`.
  
  This adds `unsafe` code to the binary, but not to the library crate.
  
  Fixes: #67 — Needs timeout or some way of dealing with slowness
  
  [`alarm()`]: https://man7.org/linux/man-pages/man2/alarm.2.html
  